### PR TITLE
Fix for special characters breaking highlighting

### DIFF
--- a/mfile
+++ b/mfile
@@ -1,6 +1,6 @@
 {
   "package": "demonhighlighter",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "author": "Demonnic",
   "title": "Configurable, game agnostic name/word/phrase highlighter",
   "icon": "highlighter.jpg",

--- a/src/aliases/highlighter/Usage.lua
+++ b/src/aliases/highlighter/Usage.lua
@@ -8,7 +8,8 @@ local msg = [[
     <0,255,255>*<r> `fg = "#ff0000", bold = true`
     <0,255,255>*<r> Available options
       <0,255,255>*<r> fg]]
-local cechomsg = [[        <cyan>*<reset> the color to make the text. Can be specified as a color name ("red"), decho style ("<255,0,0>"), or hecho style ("#ff0000")]]
+local cechomsg = [[        <cyan>*<reset> the color to make the text. Can be specified as a color name ("red"), decho style ("<255,0,0>"), or hecho style ("#ff0000")
+]]
 local msg2 = [[
         <0,255,255>*<r> defaults to false (uncolored)
       <0,255,255>*<r> bg

--- a/src/scripts/highlighter/highlighter.lua
+++ b/src/scripts/highlighter/highlighter.lua
@@ -6,7 +6,7 @@ Highlighter = Highlighter or {
   items2category = {},
   header = "<0,255,255>(<255,255,0>Highlighter<0,255,255>)<r>:"
 }
-local selectString, setBold, setUnderline, setItalics, deselect, resetFormat, setFgColor, setBgColor = selectString, setBold, setUnderline, setItalics, deselect, resetFormat, setFgColor, setBgColor
+local selectString, setBold, setUnderline, setItalics, deselect, resetFormat, setFgColor, setBgColor, find, escape = selectString, setBold, setUnderline, setItalics, deselect, resetFormat, setFgColor, setBgColor, utf8.find, utf8.patternEscape
 local savefile = getMudletHomeDir() .. "/demonhighlighter.lua"
 
 local defaultConfig = {
@@ -432,6 +432,7 @@ end
 function Highlighter:highlight(item)
   local cat = self.items2category[item]
   local conf = self.categories[cat]
+  local escapedItem = escape(item)
   local parse = Geyser.Color.parse
   if conf.paused then
     return
@@ -450,11 +451,11 @@ function Highlighter:highlight(item)
   -- c counts the appearance of the substring of the word in the line, k counts the character position
   local c, k = 1, 1
   while k > 0 do
-    k = line:find(item, k)
+    k = find(line, item, k, true)
     if k == nil then return end
     c = c + 1
 
-    if k == line:find("%f[%a]"..item.."%f[%A]", k) then
+    if (item ~= escapedItem) or (k == find(line, "%f[%a]"..item.."%f[%A]", k)) then
       if selectString(item, c-1) > -1 then
         if fg then setFgColor(unpack(fg)) end
         if bg then setBgColor(unpack(bg)) end


### PR DESCRIPTION
The secondary check for word boundaries does not play well with highlights that include special characters. As a quick workaround, we'll skip that check if we detect any special characters in the highlight item. The presence of such a character drastically reduces the likelihood of an incorrect substring match anyway.